### PR TITLE
Add support for the peers.yml option 'not_with'

### DIFF
--- a/peering_filters
+++ b/peering_filters
@@ -262,6 +262,9 @@ for asn in peerings:
         sessions = peerings[asn]['private_peerings']
     elif int(asn[2:]) in pdb:
         sessions = pdb[int(asn[2:])]
+        if 'not_with' in peerings[asn]:
+            for remove_ip in peerings[asn]['not_with']:
+                sessions.remove(remove_ip)
     else:
         continue
 


### PR DESCRIPTION
Add support for the peers.yml option 'not_with', to exclude specific peer routers from configuring a session with