### PR TITLE
Switch OSPF to also carry connected routes

### DIFF
--- a/templates/afi_specific_filters.j2
+++ b/templates/afi_specific_filters.j2
@@ -12,6 +12,16 @@ filter only_loopbacks {
     reject;
 }
 
+filter loopbacks_and_connected {
+{%- if afi == "ipv4" %}
+    if net ~ [ 94.142.247.0/28{32,32} ] then accept;
+{%- elif afi == "ipv6" %}
+    if net ~ [ 2a02:898:0:300:0:0:0:0/64{128,128} ] then accept;
+{%- endif %}
+    if (source = RTS_DEVICE) then accept;
+    reject;
+}
+
 function not_loopbacks()
 {
 {%- if afi == "ipv4" %}

--- a/templates/ospf.j2
+++ b/templates/ospf.j2
@@ -1,5 +1,5 @@
 protocol ospf ospf1 {
-    import filter loopbacks_and_connected;
+    import all;
     export filter loopbacks_and_connected;
     area 0.0.0.0 {
 {%- for interface in interfaces['backbone'] %}

--- a/templates/ospf.j2
+++ b/templates/ospf.j2
@@ -1,6 +1,6 @@
 protocol ospf ospf1 {
-    import filter only_loopbacks;
-    export filter only_loopbacks;
+    import filter loopbacks_and_connected;
+    export filter loopbacks_and_connected;
     area 0.0.0.0 {
 {%- for interface in interfaces['backbone'] %}
 {%- if interface.nic == 'lo' %}


### PR DESCRIPTION
RTS_DEVICE source is the Bird equivalent of 'directly connected' routes.
The new filter loopbacks_and_connected() will send our directly
connected internal networks. This solves a nasty problem when our
routers restart, and we have to wait for a full BGP convergence before
our own network is reachable internally: the router will announce our
prefixes to peers, and they will start sending it traffic, but the
router will not (yet) have learned our own routes internally.

For at least all directly reachable internal prefixes, OSPF can converge
much quicker (seconds rather than minutes), and these filters will allow
the following prefixes to be reachable internally much quicker:

TESTED: executed the contents of the "loopback_and_connected()" filter
on bird directly:

bird> show route filter { if net ~ [ 2a02:898:0:300:0:0:0:0/64{128,128} ] then accept; if (source = RTS_DEVICE) then accept; }
bird> show route filter { if net ~ [ 94.142.247.0/28{32,32} ] then accept; if (source = RTS_DEVICE) then accept; }

Which correctly shows connected and loopbacks. See output in mail to
routers@coloclue.net.