### PR TITLE
Redistribute statics as well to OSPF

### DIFF
--- a/templates/afi_specific_filters.j2
+++ b/templates/afi_specific_filters.j2
@@ -12,13 +12,16 @@ filter only_loopbacks {
     reject;
 }
 
-filter loopbacks_and_connected {
+filter ospf_export {
 {%- if afi == "ipv4" %}
     if net ~ [ 94.142.247.0/28{32,32} ] then accept;
+    if (net = 0.0.0.0/0) then reject;
 {%- elif afi == "ipv6" %}
     if net ~ [ 2a02:898:0:300:0:0:0:0/64{128,128} ] then accept;
+    if (net = ::/0) then reject;
 {%- endif %}
     if (source = RTS_DEVICE) then accept;
+    if (source = RTS_STATIC) then accept;
     reject;
 }
 

--- a/templates/ospf.j2
+++ b/templates/ospf.j2
@@ -1,6 +1,6 @@
 protocol ospf ospf1 {
     import all;
-    export filter loopbacks_and_connected;
+    export filter ospf_export;
     area 0.0.0.0 {
 {%- for interface in interfaces['backbone'] %}
 {%- if interface.nic == 'lo' %}


### PR DESCRIPTION
Change the name of the filter to a more concise "ospf_export". It will
now export:
- loopbacks
- never a default (0.0.0.0/0 or ::/0)
- all RTS_DEVICE (==connected routes)
- all RTS_STATIC (==static routes)

And apply this new filter to ospf.j2 for both IPv4 and IPv6. This
further adds 56 IPv4 and 42 IPv6 routes into OSPF.

TESTED: Running the filter manually:

```
bird> show route filter { if net ~ [ 94.142.247.0/28{32,32} ] then accept; if (net = 0.0.0.0/0) then reject; if (source = RTS_DEVICE) then accept; if (source = RTS_STATIC) then accept; reject; } stats
...
86 of 3204624 routes for 816587 networks

bird> show route filter { if net ~ [ 2a02:898:0:300:0:0:0:0/64{128,128} ] then accept; if (net = ::/0) then reject; if (source = RTS_DEVICE) then accept; if (source = RTS_STATIC) then accept; reject; } stats
...
63 of 423562 routes for 98599 networks
```

Indeed shows the extra routes in both address families, and does not
show a default (which our routers carry as blackhole anyway).