### PR TITLE
Make BFD a bit more lenient - avoid BGP reconvergence

### DIFF
--- a/templates/afi_specific_filters.j2
+++ b/templates/afi_specific_filters.j2
@@ -12,13 +12,16 @@ filter only_loopbacks {
     reject;
 }
 
-filter loopbacks_and_connected {
+filter ospf_export {
 {%- if afi == "ipv4" %}
     if net ~ [ 94.142.247.0/28{32,32} ] then accept;
+    if (net = 0.0.0.0/0) then reject;
 {%- elif afi == "ipv6" %}
     if net ~ [ 2a02:898:0:300:0:0:0:0/64{128,128} ] then accept;
+    if (net = ::/0) then reject;
 {%- endif %}
     if (source = RTS_DEVICE) then accept;
+    if (source = RTS_STATIC) then accept;
     reject;
 }
 

--- a/templates/header.j2
+++ b/templates/header.j2
@@ -8,6 +8,11 @@ timeformat route    iso long;
 router id {{ router_id }};
 
 protocol bfd bfd1 {
+    interface "e*.*" {
+        min rx interval 10 ms;
+        min tx interval 100 ms;
+        multiplier 20;
+    };
 }
 
 protocol kernel {

--- a/templates/ospf.j2
+++ b/templates/ospf.j2
@@ -1,6 +1,6 @@
 protocol ospf ospf1 {
     import all;
-    export filter loopbacks_and_connected;
+    export filter ospf_export;
     area 0.0.0.0 {
 {%- for interface in interfaces['backbone'] %}
 {%- if interface.nic == 'lo' %}


### PR DESCRIPTION
We've been seeing BGP reconvergence events that were traced back down to BFD failing between dcg-2 and eun-3, and this in turn is due to short periods of high latency (a simple ping shows a usual round trip time of 0.5ms but several 270ms outliers in a 5 minute sample window).

If the latency on the link exceeds the BFD timeout (which is 5 packets at 100ms intervals, so 500ms), it fails the link. BFD is turned on for OSPF links that are not physically adjacent (eg between EUN and DCG over ethernet carrier providers).

```
$ grep -B1 bfd vars/*yml
vars/dcg-1.router.nl.coloclue.net.yml-    - nic: "enp5s0f3.108"  # Backbone: Fusix
vars/dcg-1.router.nl.coloclue.net.yml:      bfd: true
--
vars/dcg-2.router.nl.coloclue.net.yml-    - nic: "eth0.3469" # naar eunetworks
vars/dcg-2.router.nl.coloclue.net.yml:      bfd: true
--
vars/eunetworks-2.router.nl.coloclue.net.yml-    - nic: "enp2s0f2.108" # Backbone: Fusix
vars/eunetworks-2.router.nl.coloclue.net.yml:      bfd: True
--
vars/eunetworks-3.router.nl.coloclue.net.yml-    - nic: "enp1s0f1.3469" # backbone to dcg
vars/eunetworks-3.router.nl.coloclue.net.yml:      bfd: true
```

The pattern of these links is to start with "e" and then have a dot1q subinterface -- thus adding a match to set a specific configuration for "e*.*" in the BFD channel.

Set the TX interval to 100ms (this is the default but we're being explicit here), and signalling a minimum RX interval of 10ms to any peer that matches this interface spec, and signal to the remote that they are to time us out after 20 missed packets (==2000ms, 2.0s), up from 500ms which is the default.

One thing of note: these values are what the *peer* uses to time out the BFD session, in other words: setting {interval:200ms, multiplier:20} on eun-3 will not show any difference in 'birdc show bfd sessions', but it will show up on dcg-2 for the session created _towards_ eun-3:

```
root@dcg-2:/etc/bird# birdc show bfd sessions
BIRD 1.6.6 ready.
bfd1:
IP address                Interface  State      Since               Interval Timeout
94.142.247.227            eth0.3469  Up         2020-11-24 21:19:24 0.100    2.000
```

TESTED: Rolled by hand on EUN-3 and observed the 'Timeout' value jump from 0.500 to 2.00 seconds. Interestingly, just before I did my test, the link between EUN-3 and DCG-2 flapped and I caught several seconds of 650ms latency, and 5 timed out packets in /var/log/daemon.log. The value of multiplier=20 may be too aggressive, still!