### PR TITLE
Move the not_ospf_export() to the export filter

### DIFF
--- a/templates/afi_specific_filters.j2
+++ b/templates/afi_specific_filters.j2
@@ -3,15 +3,6 @@
 {%- elif afi == "ipv6" -%}
 {%- set maxlength = 128 -%}
 {%- endif -%}
-filter only_loopbacks {
-{%- if afi == "ipv4" %}
-    if net ~ [ 94.142.247.0/28{32,32} ] then accept;
-{%- elif afi == "ipv6" %}
-    if net ~ [ 2a02:898:0:300:0:0:0:0/64{128,128} ] then accept;
-{%- endif %}
-    reject;
-}
-
 filter ospf_export {
 {%- if afi == "ipv4" %}
     if net ~ [ 94.142.247.0/28{32,32} ] then accept;
@@ -25,13 +16,15 @@ filter ospf_export {
     reject;
 }
 
-function not_loopbacks()
+function not_ospf_export()
 {
 {%- if afi == "ipv4" %}
     if net ~ [ 94.142.247.0/28{32,32} ] then reject;
 {%- elif afi == "ipv6" %}
     if net ~ [ 2a02:898:0:300:0:0:0:0/64{128,128} ] then reject;
 {%- endif %}
+    if (source = RTS_DEVICE) then reject;
+    if (source = RTS_STATIC) then reject;
     accept;
 }
 

--- a/templates/ibgp.j2
+++ b/templates/ibgp.j2
@@ -7,8 +7,6 @@ template bgp ibgp {
         # RFC 7999
         if (65535, 666) ~ bgp_community then dest = RTD_BLACKHOLE;
 
-        not_ospf_export();
-
         # the rest
         accept;
     };
@@ -20,6 +18,10 @@ template bgp ibgp {
         if dest = RTD_BLACKHOLE then {
             reject;
         }
+
+        # Filter out OSPF and Loopbacks
+        not_ospf_export();
+
         accept;
     };
     next hop self;


### PR DESCRIPTION
We've been moving the connected routes (#24) and static routes (#25) to be carried in OSPF.
In a followup, we changed iBGP to stop carrying these routes (#27) but after pushing, found that the filter function `not_ospf_export()` has been applied to import filtering where it doesn't make much sense, because on import, the source RTS_DEVICE and RTS_STATIC are no longer known.

Move the filter to `export` instead, where the source is known.
@Cybertinus 
