### PR TITLE
peering_filters/render(): only compile jinja2 templates once per tpl_path

### DIFF
--- a/peering_filters
+++ b/peering_filters
@@ -122,12 +122,16 @@ if 'irr_source_host' in generic:
 else:
     irr_source_host = 'rr.ntt.net'
 
+j2_templates = {}
 
 def render(tpl_path, context):
+    global j2_templates
     path, filename = os.path.split(launchdir + '/' + tpl_path)
-    return Environment(
-        loader=FileSystemLoader(path or './')
-    ).get_template(filename).render(context)
+    if tpl_path not in j2_templates:
+        j2_templates[tpl_path] = Environment(
+            loader=FileSystemLoader(path or './')
+            ).get_template(filename)
+    return j2_templates[tpl_path].render(context)
 
 
 def generate_filters(asn, as_set, irr_order, irr_source_host):


### PR DESCRIPTION
`peering_filters` uses Jinja2 templates to generate configuration snippets. At some point, @Cybertinus noted on IRC that generating configs took about 45 minutes. I was intrigued as to what would take up that amount of time. When profiling `peering_filters` (using [pprofile](https://pypi.org/project/pprofile/)), I noticed that a significant time* was spent in (re)compiling the templates:

```
Command line: ./peering_filters all
Total duration: 3618.11s
File: /usr/lib/python3.9/subprocess.py
File duration: 3094.03s (85.51%)
Line #|      Hits|         Time| Time per hit|      %|Source code
------+----------+-------------+-------------+-------+-----------
[..]
(call)|       996|      266.096|     0.267165|  7.35%|# ./peering_filters:133 render
(call)|       721|      212.985|     0.295403|  5.89%|# ./peering_filters:133 render
[..]
(call)|      1717|      473.218|     0.275607| 13.08%|# /usr/lib/python3.9/site-packages/jinja2/environment.py:862 get_template
(call)|      1717|      222.688|     0.129696|  6.15%|# /usr/lib/python3.9/site-packages/jinja2/parser.py:935 parse
(call)|      1717|      241.096|     0.140417|  6.66%|# /usr/lib/python3.9/site-packages/jinja2/compiler.py:78 generate
(call)|      1717|      225.644|     0.131418|  6.24%|# /usr/lib/python3.9/site-packages/jinja2/environment.py:537 _parse
(call)|      1717|      241.223|     0.140491|  6.67%|# /usr/lib/python3.9/site-packages/jinja2/environment.py:580 _generate
(call)|      1717|      472.623|     0.275261| 13.06%|# /usr/lib/python3.9/site-packages/jinja2/loaders.py:101 load
(call)|      1717|      473.088|     0.275532| 13.08%|# /usr/lib/python3.9/site-packages/jinja2/environment.py:846 _load_template
(call)|      1717|      468.815|     0.273043| 12.96%|# /usr/lib/python3.9/site-packages/jinja2/environment.py:603 compile
```

\* As you can see, most of the time is spent in a subprocess (`bgpq3` to be precise), but I'll leave that out of scope for now.

With this patch, the `render()` function in `peering_filters` takes just under 2 seconds\*\* _for all_ rendered configuration files:

```
Command line: ./peering_filters all
Total duration: 2785.36s
File: /usr/lib/python3.9/subprocess.py
File duration: 2747.37s (98.64%)
Line #|      Hits|         Time| Time per hit|      %|Source code
------+----------+-------------+-------------+-------+-----------
(call)|       628|      1.96026|   0.00312144|  0.07%|# ./peering_filters:134 render
(call)|       437|      1.42693|   0.00326528|  0.05%|# ./peering_filters:134 render
[..]
# when grepping: grep jinja2 20201225-pprofile-peering_filters-ipaddr-localcache-j2optimised-bgpqargs | grep -P '[^0]\.\d\d%'
# i.e. all calls that take >= 1% of the time, nothing shows up
```

\*\* The total duration in the last overview, and therefore the difference between the two runs, could be somewhat misleading. This is due to caching of rendered files that [did not need an update](https://github.com/coloclue/kees/blob/e2c58e9c10b5906cb2e590035864a268837683e6/peering_filters#L159-L168) (in this case, 5 configuration files were cached), and due to an error in another (yet unpublished) patch that checks the exit code of `bgpq3` runs. After this, `peering_filters` also exits:

```
DEBUG: bgpq args: ['bgpq3', '-h', 'rr.ntt.net', '-S', 'NTTCOM,INTERNAL,RADB,RIPE,ALTDB,BELL,LEVEL3,RGNET,APNIC,JPIRR,ARIN,BBOI,TC,AFRINIC,RPKI,ARIN-WHOIS,REGISTROBR', '-R', '24', '-4', '-b', '-l', 'AUTOFILTER_AS1
239_IPv4', '-A', 'AS1239', 'ANY']
ERROR:Unable to parse prefix 'ANY', af=2 (inet), ret=0
ERROR:Unable to parse prefix ANY
ERROR:Unable to add prefix ANY (bad prefix or address-family)
DEBUG: bgpq elapsed time: 0.002267313073389232
ERROR: bgpq3 returned non-zero for existing filename AS1239.prefixset.bird.ipv4: 1
Command line: ./peering_filters all
Total duration: 2785.36s
```

Nevertheless, the number of refreshed prefixsets (209, ipv4:104, ipv6:105) seems representative enough to me as validation of this patch.

I'll let it run again without cached prefixsets, and without exiting when `bgpq3` encountered an error, to assess the 'real' runtime.