### PR TITLE
Add ability to set localpref on IXP and Transit sessions

### DIFF
--- a/peering_filters
+++ b/peering_filters
@@ -87,8 +87,15 @@ peerings = yaml.safe_load(peerings_flat)
 ixp_map = {}
 router_map = {}
 for ixp in generic['ixp_map']:
-    ixp_map[ixp] = [ipaddr.IPNetwork(generic['ixp_map'][ixp]['ipv4_range']),
-                    ipaddr.IPNetwork(generic['ixp_map'][ixp]['ipv6_range'])]
+    ixp_map[ixp] = {}
+    ixp_map[ixp]['subnets'] = [ipaddr.IPNetwork(generic['ixp_map'][ixp]['ipv4_range']),
+                               ipaddr.IPNetwork(generic['ixp_map'][ixp]['ipv6_range'])]
+
+    # Set a default bgp_local_pref of 100, allow for IXP based override
+    ixp_map[ixp]['bgp_local_pref'] = 100
+    if 'bgp_local_pref' in generic['ixp_map'][ixp]:
+      ixp_map[ixp]['bgp_local_pref'] = generic['ixp_map'][ixp]['bgp_local_pref']
+
     router_map[ixp] = []
     for router in generic['ixp_map'][ixp]['present_on']:
         router_map[ixp].append(router)
@@ -174,8 +181,8 @@ seen_bird_peers = {}
 
 def config_snippet(asn, peer, description, ixp, router, no_filter,
                    export_full_table, limits, gtsm, peer_type,
-                   multihop, disable_multihop_source_map, multihop_source_map, generic, admin_down_state,
-                   block_importexport):
+                   multihop, disable_multihop_source_map, multihop_source_map, generic,
+                   admin_down_state, block_importexport, bgp_local_pref):
     if peer_type not in ['upstream', 'peer', 'downstream']:
         print("ERROR: invalid peertype: %s for %s" % (peer_type, asn))
         sys.exit(2)
@@ -220,7 +227,8 @@ def config_snippet(asn, peer, description, ixp, router, no_filter,
                      'ixp': ixp,
                      'rpki': generic['rpki'],
                      'admin_down_state': admin_down_state,
-                     'block_importexport': block_importexport
+                     'block_importexport': block_importexport,
+                     'bgp_local_pref': bgp_local_pref
                      }
 
         peer_config_blob = render('templates/peer.j2', peer_info)
@@ -272,9 +280,10 @@ for asn in peerings:
     for session in sessions:
         session_ip = ipaddr.IPAddress(session)
         for ixp in ixp_map:
-            for subnet in ixp_map[ixp]:
+            for subnet in ixp_map[ixp]['subnets']:
+                bgp_local_pref = ixp_map[ixp]['bgp_local_pref']
                 if session_ip in subnet:
-                    print("found peer %s in IXP %s" % (session_ip, ixp))
+                    print("found peer %s in IXP %s with localpref %d" % (session_ip, ixp, bgp_local_pref))
                     print("must deploy on %s" % " ".join(router_map[ixp]))
                     description = peerings[asn]['description']
                     for router in router_map[ixp]:
@@ -380,9 +389,8 @@ for asn in peerings:
                                     and block_importexport is False:
                                 block_importexport = \
                                     generic['bgp_groups'][ixprouter]['block_importexport']
-
                         config_snippet(asn, str(session_ip), description, ixp,
                                        router, no_filter, export_full_table,
                                        limits, gtsm, peer_type, multihop, disable_multihop_source_map,
                                        multihop_source_map, generic,
-                                       admin_down_state, block_importexport)
+                                       admin_down_state, block_importexport, bgp_local_pref)

--- a/templates/peer.j2
+++ b/templates/peer.j2
@@ -14,6 +14,9 @@ protocol bgp {{ neigh_name }} {
 {%- else %}
     import filter {{ filter_name }};
 {%- endif %}
+{%- if bgp_local_pref is defined %}
+    default bgp_local_pref {{ bgp_local_pref }};
+{%- endif %}
 {%- if block_importexport %}
     export none;
 {%- elif export_full_table %}

--- a/templates/transit.j2
+++ b/templates/transit.j2
@@ -143,6 +143,9 @@ protocol bgp transit_{{ profile_name }}_{{ loop.index }} from transit {
     import where transit_import({{ profile.tag }});
     export where transit_{{ profile_name }}_export({%- if bgp[short_hostname|replace('-', '')]['graceful_shutdown'] or profile['graceful_shutdown'] or session['graceful_shutdown'] -%}1{%- else -%}0{%- endif -%});
     {%- endif %}
+    {% if session['bgp_local_pref'] is defined -%}
+    default bgp_local_pref {{ session['bgp_local_pref'] }};
+    {%- endif %}
     {% if profile['admin_down_state'] or session['admin_down_state'] -%}
     disabled;
     {%- endif %}

--- a/vars_example/generic.yml
+++ b/vars_example/generic.yml
@@ -94,9 +94,11 @@ ixp_map:
     ipv6_range: 2001:7f8:1::/64
     present_on:
       - eunetworks-2.router.nl.coloclue.net
+#    bgp_local_pref: 100   ## The default bgp_local_pref is 100 if it is not set.
   nlix:
     ipv4_range: 193.239.116.0/22
     ipv6_range: 2001:7f8:13::/64
+    bgp_local_pref: 110
     present_on:
       - dcg-1.router.nl.coloclue.net
       - eunetworks-3.router.nl.coloclue.net

--- a/vars_example/transit.yml
+++ b/vars_example/transit.yml
@@ -14,6 +14,7 @@ transit:
           graceful_shutdown: False
           admin_down_state: False
           block_importexport: False
+          bgp_local_pref: 90
       dcg-1:
         - ip4: 172.26.1.1
           ip6: fd00:26:1::1:2


### PR DESCRIPTION
As the Coloclue network expands, we are starting to do remote peering at
SwissIX, FranceIX and DE-CIX. To do this correctly, and to avoid sending
traffic to far away places just to see it come back again, we have
decided to use BGP local preferences to steer egress traffic from
AS8283.

Before this change, localpref was 100 for any sessions, and we solely
relied on as-path length to make the routing decision. Now that we have
a mixture of 10G ports (speedix, lsix, frysix), 100M ports (decix,
franceix, swissix) and transit ports (1G/10G), it becomes more important
to do fine grained traffic engineering.

This change adds the ability to set bgp_local_pref for transit and IXP sessions.
There are two changes, a smaller one for the transit sessions (including tests), and a slightly larger one for the peering sessions (including tests).
