### PR TITLE
Add the ability to set per-ixp communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ users most likely want to run it like this:
 To prepare a Debian machine to build Kees:
 
 ```
-sudo apt install python3-pip bgpq3 jinja2 python-pip
+sudo apt install python3-pip bgpq3 python3-jinja2
 sudo pip3 install rtrsub
 sudo pip3 install numpy
 sudo pip3 install ipaddr

--- a/peering_filters
+++ b/peering_filters
@@ -209,6 +209,10 @@ def config_snippet(asn, peer, description, ixp, router, no_filter,
         if asn in generic['bgp_passwords']:
             password = generic['bgp_passwords'][asn]
 
+        ixp_community = None
+        if 'ixp_community' in generic['bgp_groups'][ixp]:
+            ixp_community = generic['bgp_groups'][ixp]['ixp_community']
+
         limit = limits[v]
         neighbor_name = base_repr(int(sha256(str(peer).encode('utf-8')).hexdigest(), 16), 36)[:6]
 
@@ -227,6 +231,7 @@ def config_snippet(asn, peer, description, ixp, router, no_filter,
                      'source': multihop_source_map[router]["ipv%s" % v],
                      'export_full_table': export_full_table,
                      'ixp': ixp,
+                     'ixp_community': ixp_community,
                      'rpki': generic['rpki'],
                      'admin_down_state': admin_down_state,
                      'block_importexport': block_importexport,

--- a/templates/filter.j2
+++ b/templates/filter.j2
@@ -42,8 +42,10 @@ prefix set {{ prefix_set }};
     bgp_community.delete((65535, 666));
     bgp_community.add((8283,1)); /* mark peering routes as peering routes */
     bgp_large_community.add((8283, 0, 1)); /* mark peering routes as peering routes */
+{% if ixp_community %}
+    bgp_large_community.add((8283, ixp_route, {{ixp_community}})); /* mark the IXP where the prefix is learned */
 {% endif %}
-
+{% endif %}
 
 {% if rpki.validation %}
     reject_rpki_invalid();

--- a/templates/header.j2
+++ b/templates/header.j2
@@ -18,6 +18,7 @@ protocol device {
     scan time 2;
 }
 
+define ixp_route = 8;                   # 8283:8:* contain the peeringdb IXP id
 define rejected_route = 7;              # bgp community 8283:7:* are reject reasons
 define r_coloclue_morespecific = 1;     # A coloclue more specific 
 define r_bogon_aspath = 2;              # a Bogon ASN appeared somewhere in the AS_PATH


### PR DESCRIPTION
Introduce ixp_community into the namespace of bgp_groups.$(ixp). IF it's set, insert it as community (8283, ixp_route, $id) where ixp_route is a token defined in the header (will get the value '8'), and the ID will come from vars/generic.yml bgp_groups scope. If it's not set, do not emit any communities. This makes the change safe to execute.

TESTED:
- With kees_config at HEAD, there is not key bgp_groups.*.ixp_community set, so this does not emit anything.
- With kees_config changed to set: bgp_groups."amsix".ixp_community: 26, this code emits  lines like: bgp_large_community.add((8283, ixp_route, 26)); /* mark the IXP where the prefix is learned */ in the router configs for peering sessions.

In a followup change to kees_config, I'll add ixp_community values based on the peeringdb ixplan identifier (AMS-IX is https://www.peeringdb.com/ix/26)