### PR TITLE
Enable RFC7999 blackhole support option for peering manifest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,10 @@ jobs:
         run: |
           pip3 install -r requirements.txt
 
+      - name: Test peers.yaml (YAML syntax)
+        run: |
+          yamllint -d "{ extends: default, rules: { line-length: { max: 120 } } }" tests/peers.yaml
+
       - name: Prepare build and staging directories
         run: |
           mkdir -p ${BUILDDIR}

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2014-2017, Job Snijders
-Copyright (c) 2017-2019, Network committee Coloclue
+Copyright (c) 2017-2023, Network committee Coloclue
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/peering_filters
+++ b/peering_filters
@@ -154,32 +154,43 @@ else:
     irr_source_host = 'rr.ntt.net'
 
 
-j2_templates = {}
-
 def render(tpl_path, context):
     path, filename = os.path.split(launchdir + '/' + tpl_path)
-    if tpl_path not in j2_templates:
-        j2_templates[tpl_path] = Environment(
-            loader=FileSystemLoader(path or './')
-            ).get_template(filename)
-    return j2_templates[tpl_path].render(context)
+    env = Environment(loader=FileSystemLoader(path or './'))
+    env.trim_blocks = True
+    env.lstrip_blocks = True
+    env.rstrip_blocks = True
 
+    return env.get_template(filename).render(context)
 
-def generate_filters(asn, as_set, irr_order, irr_source_host):
+def generate_filters(asn, as_set, irr_order, irr_source_host, loose = False):
+    # Default filter settings
+    filtername_prefix = 'AUTOFILTER'
+    filename_prefix = 'prefixset'
+    max_prefix_length = allow_upto
+
+    # Loose filtering settings
+    if (loose):
+        filtername_prefix = 'LOOSEFILTER'
+        filename_prefix = 'looseprefixset'
+        max_prefix_length = {
+            4:  "32",
+            6: "128"
+        }
 
     # inner function for actual bgpq3 execution
     def run_bgpq3(filename, v, as_set, vendor, flags, subterm, asn, irr_order, irr_source_host):
 
-        stanza_name = "AUTOFILTER_%s_IPv%s%s" % (asn, v, subterm)
+        stanza_name = "%s_%s_IPv%s%s" % (filtername_prefix, asn, v, subterm)
 
         with open(filename, "w") as bgpq3_result:
             if flags:
                 p = Popen(["bgpq3", "-h", irr_source_host, "-S", irr_order, "-R",
-                        allow_upto[v], "-%s" % v, vendor] + flags +
+                        max_prefix_length[v], "-%s" % v, vendor] + flags +
                         ["-l", stanza_name, "-A", asn] + as_set, stdout=bgpq3_result)
             else:
                 p = Popen(["bgpq3", "-h", irr_source_host, "-S", irr_order, "-R",
-                        allow_upto[v], "-%s" % v, vendor, "-l", stanza_name,
+                        max_prefix_length[v], "-%s" % v, vendor, "-l", stanza_name,
                         "-A", asn] + as_set, stdout=bgpq3_result)
         if debugmode:
             print("DEBUG: bgpq3 args: {}".format(p.args))
@@ -195,7 +206,7 @@ def generate_filters(asn, as_set, irr_order, irr_source_host):
         if as_set == "ANY":
             continue
  
-        filename = '%s.prefixset.bird.ipv%s' % (asn, v)
+        filename = '%s.%s.bird.ipv%s' % (asn, filename_prefix, v)
         if os.path.exists(filename):
             if time.time() - os.path.getmtime(filename) > 3600:
                 errno = run_bgpq3(filename, v, as_set, '-b', None, "", asn, irr_order, irr_source_host)
@@ -218,7 +229,8 @@ seen_bird_peers = {}
 def config_snippet(asn, peer, description, ixp, router, no_filter,
                    export_full_table, limits, gtsm, peer_type,
                    multihop, disable_multihop_source_map, multihop_source_map, generic,
-                   admin_down_state, block_importexport, bgp_local_pref, graceful_shutdown):
+                   admin_down_state, block_importexport, bgp_local_pref, graceful_shutdown,
+                   blackhole_accept, blackhole_community):
     if peer_type not in ['upstream', 'peer', 'downstream']:
         print("ERROR: invalid peertype: %s for %s" % (peer_type, asn))
         sys.exit(2)
@@ -270,7 +282,10 @@ def config_snippet(asn, peer, description, ixp, router, no_filter,
                      'admin_down_state': admin_down_state,
                      'block_importexport': block_importexport,
                      'bgp_local_pref': bgp_local_pref,
-                     'graceful_shutdown': graceful_shutdown
+                     'graceful_shutdown': graceful_shutdown,
+                     'blackhole_accept': blackhole_accept,
+                     'blackhole_community': blackhole_community,
+                     'loose_prefix_set': policy_name.replace('AUTOFILTER', 'LOOSEFILTER').replace(':', '_')
                      }
 
         peer_config_blob = render('templates/peer.j2', peer_info)
@@ -350,6 +365,13 @@ for asn in peerings:
             irr_order += "ARIN-WHOIS,REGISTROBR"
 
         generate_filters(asn, peerings[asn]['import'].split(), irr_order, irr_source_host)
+
+        # For peers we agree blackhole communities with, also generate a 'loose' IRR prefix set
+        if 'blackhole_accept' in peerings[asn]:
+            if peerings[asn]['blackhole_accept']:
+                loose = True
+                generate_filters(asn, peerings[asn]['import'].split(), irr_order, irr_source_host, loose) 
+
     elif (not os.path.isfile('%s.prefixset.bird.ipv4' % asn) and
           not os.path.isfile('%s.prefixset.bird.ipv6' % asn) and
           do_checks):
@@ -428,6 +450,14 @@ for asn in peerings:
                             if peerings[asn]['disable_multihop_source_map']:
                                 disable_multihop_source_map = True
 
+                        blackhole_accept = False
+                        if 'blackhole_accept' in peerings[asn]:
+                            blackhole_accept = peerings[asn]['blackhole_accept']
+                        
+                        blackhole_community = [ '65535:666' ]
+                        if 'blackhole_community' in peerings[asn]:
+                            blackhole_community = peerings[asn]['blackhole_community']
+
                         ixprouter = ixp + '-' + routershort
                         admin_down_state = False
                         # Is the IXP defined in the bgp_groups settings
@@ -485,4 +515,5 @@ for asn in peerings:
                                        router, no_filter, export_full_table,
                                        limits, gtsm, peer_type, multihop, disable_multihop_source_map,
                                        multihop_source_map, generic,
-                                       admin_down_state, block_importexport, bgp_local_pref, graceful_shutdown)
+                                       admin_down_state, block_importexport, bgp_local_pref, graceful_shutdown,
+                                       blackhole_accept, blackhole_community)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numpy  # https://numpy.org/
 requests  # https://requests.readthedocs.io/en/master/
 rtrsub  # https://github.com/job/rtrsub
 pyyaml  # https://github.com/yaml/pyyaml
+yamllint  # https://pypi.org/project/yamllint/  

--- a/templates/filter.j2
+++ b/templates/filter.j2
@@ -1,6 +1,9 @@
 
 filter peer_in_AS{{ asn }}_ipv{{ afi }}
 prefix set {{ prefix_set }};
+{% if blackhole_accept %}
+prefix set {{ loose_prefix_set }};  # Loose IRR filter for blackhole use
+{% endif %}
 {
     # ignore bogon AS_PATHs
     if is_bogon_aspath() then {
@@ -34,12 +37,22 @@ prefix set {{ prefix_set }};
     bgp_local_pref = 0;
 {% endif %}
 
+{% if blackhole_accept %}
+    if ( (65535, 666) ~ bgp_community) && net ~ {{ loose_prefix_set }}) then {
+        print "Accept blackhole: ", net, " filter: peer_in_AS{{ asn }}_ipv{{ afi }}";
+        dest = RTD_BLACKHOLE;
+        accept;
+    }
+{% endif %}
+
 {% if peer_type == "peer" %}
     # Scrub BGP Communities (RFC 7454 Section 11) from peering partners
     bgp_community.delete([(8283, *)]);
     bgp_large_community.delete([(8283, *, *)]);
+{% if not blackhole_accept %}
     # Scrub BLACKHOLE Community from peering partners
     bgp_community.delete((65535, 666));
+{% endif %}
     bgp_community.add((8283,1)); /* mark peering routes as peering routes */
     bgp_large_community.add((8283, 0, 1)); /* mark peering routes as peering routes */
 {% if ixp_community %}
@@ -52,6 +65,9 @@ prefix set {{ prefix_set }};
 {% endif %}
 
     include "AS{{ asn }}.prefixset.bird.ipv{{ afi }}";
+{% if blackhole_accept %}
+    include "AS{{ asn }}.looseprefixset.bird.ipv{{ afi }}";
+{% endif %}
     if (net ~ {{ prefix_set }}{% if rpki.validation %} || (8283, 5, 2) ~ bgp_large_community{% endif %}) then {
         bgp_med = 0;
 

--- a/templates/filter.j2
+++ b/templates/filter.j2
@@ -38,6 +38,9 @@ prefix set {{ loose_prefix_set }};  # Loose IRR filter for blackhole use
 {% endif %}
 
 {% if blackhole_accept %}
+    # Per the peering manifest, we accept blackhole routes for this peer.
+    # For blackholed routes, we use loose IRR filtering
+    include "AS{{ asn }}.looseprefixset.bird.ipv{{ afi }}";
     if ( (65535, 666) ~ bgp_community) && net ~ {{ loose_prefix_set }}) then {
         print "Accept blackhole: ", net, " filter: peer_in_AS{{ asn }}_ipv{{ afi }}";
         dest = RTD_BLACKHOLE;
@@ -49,10 +52,13 @@ prefix set {{ loose_prefix_set }};  # Loose IRR filter for blackhole use
     # Scrub BGP Communities (RFC 7454 Section 11) from peering partners
     bgp_community.delete([(8283, *)]);
     bgp_large_community.delete([(8283, *, *)]);
+
 {% if not blackhole_accept %}
     # Scrub BLACKHOLE Community from peering partners
     bgp_community.delete((65535, 666));
+
 {% endif %}
+    # Mark peering routes with our BGP communities
     bgp_community.add((8283,1)); /* mark peering routes as peering routes */
     bgp_large_community.add((8283, 0, 1)); /* mark peering routes as peering routes */
 {% if ixp_community %}
@@ -65,9 +71,6 @@ prefix set {{ loose_prefix_set }};  # Loose IRR filter for blackhole use
 {% endif %}
 
     include "AS{{ asn }}.prefixset.bird.ipv{{ afi }}";
-{% if blackhole_accept %}
-    include "AS{{ asn }}.looseprefixset.bird.ipv{{ afi }}";
-{% endif %}
     if (net ~ {{ prefix_set }}{% if rpki.validation %} || (8283, 5, 2) ~ bgp_large_community{% endif %}) then {
         bgp_med = 0;
 

--- a/templates/peer.j2
+++ b/templates/peer.j2
@@ -4,45 +4,45 @@ protocol bgp {{ neigh_name }} {
     neighbor {{ neigh_ip }} as {{ asn }};
     include "../ebgp_state.conf";
     local as 8283;
-{%- if bgp_local_pref is defined %}
+    {% if bgp_local_pref is defined %}
     default bgp_local_pref {{ bgp_local_pref }};
-{%- endif %}
+    {% endif %}
     ipv{{ afi|replace('ipv', '') }} {
         next hop self;
-{%- if limit is greaterthan 0 %}
+    {% if limit is greaterthan 0 %}
         receive limit {{ limit }} action restart;
-{%- endif %}
+    {% endif %}
         import keep filtered;
-{%- if block_importexport %}
+    {% if block_importexport %}
         import none;
-{%- else %}
+    {% else %}
         import filter {{ filter_name }};
-{%- endif %}
-{%- if block_importexport %}
+    {% endif %}
+    {% if block_importexport %}
         export none;
-{%- elif export_full_table %}
+    {% elif export_full_table %}
         export where full_table_export({{ asn }}, {%- if graceful_shutdown -%}1{%- else -%}0{%- endif -%});
-{%- else %}
+    {% else %}
         export where ebgp_peering_export({{ asn }}, {%- if graceful_shutdown -%}1{%- else -%}0{%- endif -%});
-{%- endif %}
+    {% endif %}
     };
-{%- if password %}
+    {% if password %}
     password "{{ password }}";
-{%- endif %}
-{%- if gtsm %}
+    {% endif %}
+    {% if gtsm %}
     ttl security on;
-{%- endif %}
-{%- if multihop %}
+    {% endif %}
+    {% if multihop %}
     multihop;
-    {%- if not disable_multihop_source_map %}
+        {% if not disable_multihop_source_map %}
     source address {{ source }};
-    {%- endif %}
-{%- endif %}
-{%- if admin_down_state %}
+        {% endif %}
+    {% endif %}
+    {% if admin_down_state %}
     disabled;
-{%- endif %}
-{%- if graceful_shutdown %}
+    {% endif %}
+    {% if graceful_shutdown %}
     default bgp_local_pref 0;
-{%- endif %}
+    {% endif %}
 }
 

--- a/tests/peers.yaml
+++ b/tests/peers.yaml
@@ -2,7 +2,7 @@
 # Test set for Kees CI pipeline
 # Limit the number of ASNs, but ensure we keep:
 #   * IXP route servers (AS6777, AS34307, AS56393)
-#   * Blackhole-capable IXP route servers (AS6695)
+#   * Blackhole-capable IXP route servers (AS42476)
 #   * Peers we explicitly include/exclude for given IXPs (AS6939, AS8298)
 #   * Peers we use non-standard AS-SETs with (AS15562)
 #   * Peers that override PeeringDB settings (AS1299, AS3320, AS6453)
@@ -22,7 +22,7 @@ AS1299:
     export: "AS8283:AS-COLOCLUE"
     ipv4_limit: 605000
     ipv6_limit: 110000
-    ignore_peeringdb: True
+    ignore_peeringdb: true
     private_peerings:
         - 62.115.144.32
         - 2001:2000:3080:0EBC::1
@@ -31,7 +31,7 @@ AS3320:
     description: Deutsche Telekom
     import: AS3320:AS-DTAG AS3320:AS-CUSTOMERS-V6
     export: "AS8283:AS-COLOCLUE"
-    ignore_peeringdb: True
+    ignore_peeringdb: true
     only_with:
         - 80.249.209.211
         - 2001:7f8:1::a500:3320:1
@@ -40,7 +40,7 @@ AS6453:
     description: Tata
     import: AS-GLOBEINTERNET
     export: "AS8283:AS-COLOCLUE"
-    ignore_peeringdb: True
+    ignore_peeringdb: true
     only_with:
         - 80.249.209.167
         - 2001:7f8:1::a500:6453:1
@@ -64,9 +64,9 @@ AS8298:
     import: AS-IPNG
     export: AS8283:AS-COLOCLUE
     not_on:
-        #- decix
+        # - decix
         - franceix
-        #- swissix
+        # - swissix
 
 AS13335:
     description: Cloudflare
@@ -124,6 +124,13 @@ AS41441:
     description: SPEED-IX route server peers
     import: AS-IX
     export: AS8283:AS-COLOCLUE
+
+AS42476:
+    description: SwissIX Route Servers
+    import: AS-SWISSIX-RS
+    export: AS8283:AS-COLOCLUE
+    # https://www.swissix.ch/resources/blackholing-guide/
+    blackhole_accept: true
 
 AS56393:
     description: Frys-IX Route Servers


### PR DESCRIPTION
Enables RFC7999 blackhole support via the `blackhole_accept` option in our [peering manifest](https://github.com/coloclue/peering). This is typically foreseen for route server peers that document this practice, such as [Swiss-IX](https://www.swissix.ch/resources/blackholing-guide/) and [DE-CIX](https://de-cix.net/en/resources/faqs#Blackholing).

For peers with this option enabled, we generate:
* import filters that *accept and blackhole* routes tagged with the BLACKHOLE community;
* an extra prefix sets for 'loose' IRR filtering of blackhole-tagged routes (`LOOSEFILTER_${ASN}_${AFI}`)

We still subject BLACKHOLE-tagged routes to a 'loose' IRR filter/prefix set for the peer ASN.

The 'loose' IRR filtering prefix set is nothing more than the regularly generated prefix set, with its max prefix length set to 32/128 bits for IPv4/6 respectively via `bgpq3`'s `-R` option.

Finally, a (bare-bones) test case is also added to the on-board `peers.yaml` file, to ensure we generate some of these filters and catch errors.


# Testing

[X] Passes the automated [CI tests](https://github.com/rkrieger/coloclue-kees/actions/runs/6473598526/job/17576657896)
[X] Confirmed no-op for other peers (except intended whitespace clean-up in filter/protocols)
[X] Confirmed no-op for other Bird configuration files

Example for a blackhole-enabled peer filter:
```
filter peer_in_AS42476_ipv4
prefix set AUTOFILTER_AS42476_IPv4;
prefix set LOOSEFILTER_AS42476_IPv4;  # Loose IRR filter for blackhole use
{
    # ignore bogon AS_PATHs
    if is_bogon_aspath() then {
        print "Reject: bogon AS_PATH: ", net, " ", bgp_path;
        bgp_large_community.add((8283, rejected_route, r_bogon_aspath));
        reject;
    }

    if ( is_coloclue_more_specific() ) then {
        print "Reject: 8283 more specific: ", net, " ", bgp_path, " filter: peer_in_AS42476_ipv4";
        bgp_large_community.add((8283, rejected_route, r_coloclue_morespecific));
        reject;
    }
    if ( is_bogon() ) then {
        print "Reject: bogon: ", net, " ", bgp_path, " filter: peer_in_AS42476_ipv4";
        bgp_large_community.add((8283, rejected_route, r_bogon_prefix));
        reject;
    }

    if ! is_acceptable_size() then {
        print "Reject: too large or too small: ", net, " ", bgp_path, " filter: peer_in_AS42476_ipv4";
        bgp_large_community.add((8283, rejected_route, r_unacceptable_pfxlen));
        reject;
    }

    # https://tools.ietf.org/html/rfc8326
    allow_graceful_shutdown();


    # Per the peering manifest, we accept blackhole routes for this peer.
    # For blackholed routes, we use loose IRR filtering
    include "AS42476.looseprefixset.bird.ipv4";
    if ( (65535, 666) ~ bgp_community) && net ~ LOOSEFILTER_AS42476_IPv4) then {
        print "Accept blackhole: ", net, " filter: peer_in_AS42476_ipv4";
        dest = RTD_BLACKHOLE;
        accept;
    }

    # Scrub BGP Communities (RFC 7454 Section 11) from peering partners
    bgp_community.delete([(8283, *)]);
    bgp_large_community.delete([(8283, *, *)]);

    # Mark peering routes with our BGP communities
    bgp_community.add((8283,1)); /* mark peering routes as peering routes */
    bgp_large_community.add((8283, 0, 1)); /* mark peering routes as peering routes */
    bgp_large_community.add((8283, ixp_route, 60)); /* mark the IXP where the prefix is learned */

    reject_rpki_invalid();

    include "AS42476.prefixset.bird.ipv4";
    if (net ~ AUTOFILTER_AS42476_IPv4 || (8283, 5, 2) ~ bgp_large_community) then {
        bgp_med = 0;
        # classifications
        if (net ~ AUTOFILTER_AS42476_IPv4) then {
            bgp_community.add((8283, 101));
            bgp_large_community.add((8283, 5, 1));
        }
       accept;
    }
    print "Reject: No IRR? ", net, " ", bgp_path, " filter: peer_in_AS42476_ipv4";
    bgp_large_community.add((8283, rejected_route, r_no_irr));
    reject;
}
```

Partial snippet of a 'loose' IRR filter:
```
LOOSEFILTER_AS42476_IPv4 = [
    1.0.0.0/24{24,32},
    1.0.4.0/22{22,32},
    1.0.16.0/24{24,32},
    1.0.32.0/24{24,32},
    1.0.38.0/23{23,32},
    1.0.40.0/21{21,32},
<snip>
```

# Caveats

Although the test peering configuration already covers customized blackhole communities, the code currently only supports the [RFC7999](https://www.rfc-editor.org/rfc/rfc7999.html) 65535:666 community.

This PR also changes the jinja templating to use `lstrip_blocks` and `trim_blocks` to more predictably/easily handle whitespace in Jinja templates. This lets the `peer.j2` and `filter.j2` templates use more flexible placement of template conditions without needing the maddening `{%-` and `-%}` tags.


# Miscellanea

While there, clean up some copyright dates.